### PR TITLE
Dechunker replays “completed” event

### DIFF
--- a/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/Dechunker.java
+++ b/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/Dechunker.java
@@ -65,6 +65,7 @@ public class Dechunker implements FlowableOperator<String, String> {
             if (!previous.isEmpty()) {
                 child.onNext(previous);
             }
+            child.onComplete();
         }
 
         @Override

--- a/modules/java/src/test/java/be/wegenenverkeer/designtests/RxHttpClientTestChunkedResponse.java
+++ b/modules/java/src/test/java/be/wegenenverkeer/designtests/RxHttpClientTestChunkedResponse.java
@@ -99,6 +99,8 @@ public class RxHttpClientTestChunkedResponse extends UsingWireMockRxJava {
         TestSubscriber<String> subscriber = flowable.test();
         subscriber.awaitDone(20_000, TimeUnit.MILLISECONDS);
 
+        subscriber.assertComplete();
+        subscriber.assertNoErrors();
         subscriber.assertValueCount(SIZE);
     }
 


### PR DESCRIPTION
An `executeAndDechunk` should complete if the underlying source completes.