### PR TITLE
Move blocking logger operation to io thread

### DIFF
--- a/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/RxJavaHttpClient.java
+++ b/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/RxJavaHttpClient.java
@@ -4,6 +4,7 @@ import be.wegenenverkeer.rxhttpclient.*;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.processors.AsyncProcessor;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.asynchttpclient.AsyncHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class RxJavaHttpClient extends BaseRxHttpClient implements RxHttpClient {
             AsyncProcessor<F> subject = AsyncProcessor.create();
             inner().executeRequest(request.unwrap(), new AsyncCompletionHandlerWrapper<>(subject, transformer));
             return subject;
-        });
+        }).subscribeOn(Schedulers.io());
     }
 
     /**


### PR DESCRIPTION
Hi! :) 
We found a blocking call in `RxJavaHttpClient` class via BlockHound. Apparently logger.info is blocking the reactive pipeline:
<img width="1120" alt="Screen Shot 2023-07-20 at 4 28 14 PM" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/3f3a1137-1d90-4310-9c14-45fc2f878ebc">

This PR fixes the blocking call. We re-ran the tests and also validated the performance improvement (in terms of memory usage) before and after the fix:
**Before**
<img width="418" alt="rxhttp1-memory-before" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/7cd86c2a-c651-4ff2-b129-04bda1b5c1b0">

**After**
<img width="410" alt="rxhttp1-memory-after" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/0a52cb50-ebcd-4b1a-b042-b8dd5711109e">
