### PR TITLE
Move blocking handler methods execution to executor thread

### DIFF
--- a/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/CompleteResponseHandler.java
+++ b/modules/java/src/main/java/be/wegenenverkeer/rxhttpclient/rxjava/CompleteResponseHandler.java
@@ -5,13 +5,15 @@ import be.wegenenverkeer.rxhttpclient.HttpServerError;
 import be.wegenenverkeer.rxhttpclient.ServerResponse;
 import org.asynchttpclient.Response;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 26/02/15.
  */
 class CompleteResponseHandler {
-
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
     public static void withCompleteResponse(
             Response response,
             Consumer<Response> handleSuccess,
@@ -19,13 +21,15 @@ class CompleteResponseHandler {
             Consumer<Throwable> handleServerError
     ) {
         int status = response.getStatusCode();
-        if (status < 400) {
-            handleSuccess.accept(response);
-        } else if (status < 500) {
-            handleClientError.accept(new HttpClientError(status, ServerResponse.wrap(response), "request failed with status = " + response.getStatusText()));
-        } else {
-            handleServerError.accept(new HttpServerError(status, ServerResponse.wrap(response), "request failed with status = " + response.getStatusText()));
-        }
+        executor.execute(() -> {
+            if (status < 400) {
+                handleSuccess.accept(response);
+            } else if (status < 500) {
+                handleClientError.accept(new HttpClientError(status, ServerResponse.wrap(response), "request failed with status = " + response.getStatusText()));
+            } else {
+                handleServerError.accept(new HttpServerError(status, ServerResponse.wrap(response), "request failed with status = " + response.getStatusText()));
+            }
+        });
     }
 
 }


### PR DESCRIPTION
H! 👋 

We found some blocking code in `CompleteResponseHandler` class, with the help of BlockHound:
<img width="1201" alt="http2-blocking" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/fe1db2b9-868b-443a-82a9-36f7df747b9b">

This PR fixes the code so that the pipeline remains reactive end to end. We re-ran the test cases after the fix and also compared the performance (memory and latency) before and after the fix:

**Before**
<img width="930" alt="http2-latency-before" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/05fd10e1-6c3a-4c49-837b-3eed165eea50">
<img width="404" alt="http2-memory-before" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/8261d83f-fc3d-4bc6-b9a8-8a55dcdba0c8">


**After**
<img width="969" alt="http2-latency-after" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/3516d482-344c-4519-b456-b4274b356aca">
<img width="406" alt="http2-memory-after" src="https://github.com/WegenenVerkeer/RxHttpClient/assets/56495631/c1b6fe25-b13f-4541-af1f-f6e34f4994dd">
