### PR TITLE
Upgrade dependencies to fix known vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [master, 'security/**']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Run tests (cross-built)
+        run: sbt -batch +clean +test

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,20 @@ val ScalaBuildOptions = Seq("-unchecked",
                             "-target:jvm-1.8")
 
 
-val asyncClient = "org.asynchttpclient" % "async-http-client" % "2.12.1"
+val asyncClient = "org.asynchttpclient" % "async-http-client" % "2.16.0"
+
+// Pin Netty above the 4.1.133.Final that async-http-client 2.16.0 pulls in:
+// 4.1.135+ fixes GHSA-hvcg-qmg6-jm4c (netty-codec-http) and GHSA-3qp7-7mw8-wx86 (netty-handler).
+// The native transports carry the same classifiers AHC declares: the classifier is part
+// of Maven's conflict key, so unclassified pins would leave the 4.1.133 native jars in
+// downstream dependency graphs.
+val nettyVersion = "4.1.136.Final"
+val nettyCodecHttp = "io.netty" % "netty-codec-http" % nettyVersion
+val nettyCodecSocks = "io.netty" % "netty-codec-socks" % nettyVersion
+val nettyHandler = "io.netty" % "netty-handler" % nettyVersion
+val nettyHandlerProxy = "io.netty" % "netty-handler-proxy" % nettyVersion
+val nettyNativeEpoll = ("io.netty" % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
+val nettyNativeKqueue = ("io.netty" % "netty-transport-native-kqueue" % nettyVersion).classifier("osx-x86_64")
 
 val rxStreamsVersion = "1.0.3"
 val rxJavaVersion = "3.1.5"
@@ -23,7 +36,9 @@ val fs2Version = "2.2.2"
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.30"
 val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
-val json = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.3" % "provided"
+val json = "com.fasterxml.jackson.core" % "jackson-databind" % "2.22.1" % "provided"
+val jsonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.22.1" % "provided"
+val jsonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % "2.22" % "provided"
 val rx = "org.reactivestreams" % "reactive-streams" % rxStreamsVersion
 val reactorAdapter = "io.projectreactor.addons" % "reactor-adapter" % reactorVersion
 val reactorTest = "io.projectreactor" % "reactor-test" % reactorVersion % "test"
@@ -41,7 +56,15 @@ val commonDependencies = Seq(
   asyncClient,
   slf4j,
   commonsCodec,
-  json
+  json,
+  jsonCore,
+  jsonAnnotations,
+  nettyCodecHttp,
+  nettyCodecSocks,
+  nettyHandler,
+  nettyHandlerProxy,
+  nettyNativeEpoll,
+  nettyNativeKqueue
 )
 
 val rxJavaDependencies = Seq(

--- a/modules/fs2/src/test/scala/WireMockSupport.scala
+++ b/modules/fs2/src/test/scala/WireMockSupport.scala
@@ -10,7 +10,7 @@ import org.specs2.specification.BeforeAfterEach
  */
 trait WireMockSupport extends BeforeAfterEach {
 
-  val REQUEST_TIME_OUT = 200_000
+  val REQUEST_TIME_OUT = 200000
   val DEFAULT_TIME_OUT: Int = REQUEST_TIME_OUT * 5
 
   val server: WireMockServer = new WireMockServer(options()

--- a/modules/java/src/test/java/be/wegenenverkeer/rxhttpclient/TestBuilder.java
+++ b/modules/java/src/test/java/be/wegenenverkeer/rxhttpclient/TestBuilder.java
@@ -15,6 +15,14 @@ public class TestBuilder {
         new RxJavaHttpClient.Builder().build();
     }
 
+    //Netty >= 4.1.135 rejects header values with leading/trailing whitespace, so since
+    //async-http-client 2.16.0 such requests fail at construction instead of being sent.
+    @Test(expected = IllegalArgumentException.class)
+    public void testHeaderValueWithLeadingOrTrailingWhitespaceIsRejected() {
+        RxHttpClient client = new RxJavaHttpClient.Builder().setBaseUrl("http://foo.com").build();
+        client.requestBuilder().addHeader("p", " phfft ");
+    }
+
     @Test
     public void testRequestSignersAreAdded() {
         RequestSigner requestSigner = clientRequest -> {

--- a/modules/java/src/test/java/be/wegenenverkeer/rxhttpclient/aws/Aws4TestSuite.java
+++ b/modules/java/src/test/java/be/wegenenverkeer/rxhttpclient/aws/Aws4TestSuite.java
@@ -47,6 +47,11 @@ public class Aws4TestSuite implements Iterable<Aws4TestCase> {
         return Stream.of(sourceDirectory.list((File dir, String name) -> name.endsWith(".req")))
                 //TODO -- remove this when PR #1601 is accepted in async upstream!!!
                 .filter(fn -> !fn.startsWith("get-vanilla-query-unreserved"))
+                //Netty >= 4.1.135 rejects header values with leading/trailing whitespace at
+                //request construction, so the untrimmed value in this vector can no longer be
+                //built, let alone signed. The new contract is covered by
+                //TestBuilder#testHeaderValueWithLeadingOrTrailingWhitespaceIsRejected.
+                .filter(fn -> !fn.startsWith("get-header-value-trim"))
                 .map(this::parseRequest).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
- async-http-client 2.12.1 -> 2.16.0: fixes CVE-2024-53990 (CookieStore replacing explicit cookies), CVE-2026-40490 (Authorization/Realm leak on cross-origin redirects) and CVE-2026-45300 (cookie leak on cross-origin redirects).
- Pin Netty to 4.1.136.Final: AHC 2.16.0 ships 4.1.133.Final, still affected by GHSA-hvcg-qmg6-jm4c and GHSA-3qp7-7mw8-wx86 (fixed in 4.1.135). Declared as regular dependencies so the pins reach the published POM and downstream consumers. The native transports are pinned with the same classifiers AHC declares (linux-x86_64, osx-x86_64), because the classifier is part of Maven's conflict key: unclassified pins would leave the 4.1.133 native jars in downstream dependency graphs.
- jackson-databind 2.10.3 -> 2.22.1, with jackson-core 2.22.1 and jackson-annotations 2.22 pinned in lockstep (wiremock otherwise pulls older annotations onto the test classpath, breaking ObjectMapper). Note: GHSA-5jmj-h7xm-6q6v remains open on all jackson-databind 2.x (fix only exists in Jackson 3); not exploitable here (single readValue into JsonNode, provided scope).

Behavioral changes inherited from upstream security fixes: AHC no longer forwards Authorization headers or cookies on cross-origin redirects, and Netty >= 4.1.135 rejects header values with leading/trailing whitespace at request construction. Such requests are now unrepresentable, so the aws4 get-header-value-trim vector is explicitly skipped and the new contract is covered by a test in TestBuilder.

Also fix the Scala 2.12 cross-build of the fs2 tests (2.13-only underscore literal).